### PR TITLE
Fix ESM-CJS compatibility (#36)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@unified-latex/unified-latex-util-parse": "1.3.2",
-        "docx": "^8.0.4",
-        "unist-util-visit": "^4.1.0"
+        "docx": "^8.1.0",
+        "unist-util-visit": "^4.1.2"
       },
       "devDependencies": {
         "@babel/core": "7.20.12",
@@ -5855,9 +5855,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.0.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.4.tgz",
-      "integrity": "sha512-M0+G6V0Y4YV8cqzHssZpaNCqvYwlCiulmm0PwpNLF55r/+cT8Ol42CHRU1SEaYFH2rTwiiE1aYg/2g2rrtGdPA=="
+      "version": "20.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.2.tgz",
+      "integrity": "sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.3",
@@ -7868,13 +7868,14 @@
       }
     },
     "node_modules/docx": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/docx/-/docx-8.0.4.tgz",
-      "integrity": "sha512-bPS/UyWnflcr46JugKZVv8BBNIAVjvWbGOBvvWS21n14MQite78EO09GqNEpckG7kYsQqUzEPVsigErXKTrdFA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-8.1.0.tgz",
+      "integrity": "sha512-rgIDP0MCD5xlA//9s+lAekGe0NgYIrFt/Fj1JNjRLsbGm4EWQ9gz8j4H0thVsdLbGFTV7UV6+BSbeDj+tjfRBg==",
       "dependencies": {
-        "@types/node": "^18.0.0",
-        "jszip": "^3.1.5",
-        "nanoid": "^3.3.4",
+        "@types/node": "^20.3.1",
+        "fflate": "^0.8.0",
+        "jszip": "^3.10.1",
+        "nanoid": "^4.0.2",
         "xml": "^1.0.1",
         "xml-js": "^1.6.8"
       },
@@ -7889,6 +7890,23 @@
       "dev": true,
       "dependencies": {
         "jszip": ">=3.0.0"
+      }
+    },
+    "node_modules/docx/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/dotenv": {
@@ -8539,6 +8557,11 @@
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.5.tgz",
       "integrity": "sha512-q9SvpKH5Ka6h7X2C6r1sP31pQoeDb3o6/R9cg21ahfPAqbIOkW9tus1dXfwYb6G6dOI4F7nVS4Q+LSssBGIz0A==",
       "dev": true
+    },
+    "node_modules/fflate": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.0.tgz",
+      "integrity": "sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg=="
     },
     "node_modules/file-saver": {
       "version": "2.0.5",
@@ -11650,14 +11673,14 @@
       }
     },
     "node_modules/jszip": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
-      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
+        "setimmediate": "^1.0.5"
       }
     },
     "node_modules/katex": {
@@ -13011,6 +13034,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
       "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14693,13 +14717,10 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
-    "node_modules/set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -16255,7 +16276,7 @@
     "node_modules/xml": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
     },
     "node_modules/xml-js": {
       "version": "1.6.11",
@@ -20500,9 +20521,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.0.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.4.tgz",
-      "integrity": "sha512-M0+G6V0Y4YV8cqzHssZpaNCqvYwlCiulmm0PwpNLF55r/+cT8Ol42CHRU1SEaYFH2rTwiiE1aYg/2g2rrtGdPA=="
+      "version": "20.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.2.tgz",
+      "integrity": "sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw=="
     },
     "@types/node-fetch": {
       "version": "2.6.3",
@@ -22071,15 +22092,23 @@
       }
     },
     "docx": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/docx/-/docx-8.0.4.tgz",
-      "integrity": "sha512-bPS/UyWnflcr46JugKZVv8BBNIAVjvWbGOBvvWS21n14MQite78EO09GqNEpckG7kYsQqUzEPVsigErXKTrdFA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-8.1.0.tgz",
+      "integrity": "sha512-rgIDP0MCD5xlA//9s+lAekGe0NgYIrFt/Fj1JNjRLsbGm4EWQ9gz8j4H0thVsdLbGFTV7UV6+BSbeDj+tjfRBg==",
       "requires": {
-        "@types/node": "^18.0.0",
-        "jszip": "^3.1.5",
-        "nanoid": "^3.3.4",
+        "@types/node": "^20.3.1",
+        "fflate": "^0.8.0",
+        "jszip": "^3.10.1",
+        "nanoid": "^4.0.2",
         "xml": "^1.0.1",
         "xml-js": "^1.6.8"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        }
       }
     },
     "docx-preview": {
@@ -22596,6 +22625,11 @@
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.5.tgz",
       "integrity": "sha512-q9SvpKH5Ka6h7X2C6r1sP31pQoeDb3o6/R9cg21ahfPAqbIOkW9tus1dXfwYb6G6dOI4F7nVS4Q+LSssBGIz0A==",
       "dev": true
+    },
+    "fflate": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.0.tgz",
+      "integrity": "sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg=="
     },
     "file-saver": {
       "version": "2.0.5",
@@ -24867,14 +24901,14 @@
       }
     },
     "jszip": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
-      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
+        "setimmediate": "^1.0.5"
       }
     },
     "katex": {
@@ -25796,7 +25830,8 @@
     "nanoid": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -27064,10 +27099,10 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -28222,7 +28257,7 @@
     "xml": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
     },
     "xml-js": {
       "version": "1.6.11",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "remark plugin to compile markdown to docx (Microsoft Word, Office Open XML).",
   "main": "lib/index.js",
   "module": "lib/index.mjs",
+  "exports": {
+    "require": "./lib/index.js",
+    "import": "./lib/index.mjs"
+  },
   "types": "lib/index.d.ts",
   "files": [
     "lib"
@@ -20,8 +24,8 @@
   },
   "dependencies": {
     "@unified-latex/unified-latex-util-parse": "1.3.2",
-    "docx": "^8.0.4",
-    "unist-util-visit": "^4.1.0"
+    "docx": "^8.1.0",
+    "unist-util-visit": "^4.1.2"
   },
   "devDependencies": {
     "@babel/core": "7.20.12",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,5 +1,8 @@
 import typescript from "@rollup/plugin-typescript";
-import pkg from "./package.json" assert { type: "json" };
+import fs from "node:fs";
+
+const pkgLoc = new URL("./package.json", import.meta.url);
+const pkg = JSON.parse(fs.readFileSync(pkgLoc, "utf8"));
 
 const externals = [
   ...Object.keys(pkg.dependencies),

--- a/src/__snapshots__/latex.spec.ts.snap
+++ b/src/__snapshots__/latex.spec.ts.snap
@@ -3,9 +3,9 @@
 exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi i \\xi x}\\,d\\xi 1`] = `
 [
   [
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "f",
           ],
@@ -14,9 +14,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "relax",
           ],
@@ -25,9 +25,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "x",
           ],
@@ -36,9 +36,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "=",
           ],
@@ -47,25 +47,25 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
       ],
       "rootKey": "m:r",
     },
-    fs {
+    MathSuperScript {
       "root": [
-        ds {
+        MathSuperScriptProperties {
           "root": [],
           "rootKey": "m:sSupPr",
         },
-        ts {
+        MathBase {
           "root": [
-            ws {
+            MathSubScript {
               "root": [
-                ms {
+                MathSubScriptProperties {
                   "root": [],
                   "rootKey": "m:sSubPr",
                 },
-                ts {
+                MathBase {
                   "root": [
-                    $n {
+                    MathRun {
                       "root": [
-                        Xn {
+                        MathText {
                           "root": [
                             "∫",
                           ],
@@ -77,11 +77,11 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
                   ],
                   "rootKey": "m:e",
                 },
-                us {
+                MathSubScriptElement {
                   "root": [
-                    $n {
+                    MathRun {
                       "root": [
-                        Xn {
+                        MathText {
                           "root": [
                             "-",
                           ],
@@ -90,9 +90,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
                       ],
                       "rootKey": "m:r",
                     },
-                    $n {
+                    MathRun {
                       "root": [
-                        Xn {
+                        MathText {
                           "root": [
                             "∞",
                           ],
@@ -110,11 +110,11 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
           ],
           "rootKey": "m:e",
         },
-        ls {
+        MathSuperScriptElement {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "∞",
                   ],
@@ -129,9 +129,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
       ],
       "rootKey": "m:sSup",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "f",
           ],
@@ -140,9 +140,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "hat",
           ],
@@ -151,9 +151,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ξ",
           ],
@@ -162,9 +162,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             ",",
           ],
@@ -173,17 +173,17 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
       ],
       "rootKey": "m:r",
     },
-    fs {
+    MathSuperScript {
       "root": [
-        ds {
+        MathSuperScriptProperties {
           "root": [],
           "rootKey": "m:sSupPr",
         },
-        ts {
+        MathBase {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "e",
                   ],
@@ -195,11 +195,11 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
           ],
           "rootKey": "m:e",
         },
-        ls {
+        MathSuperScriptElement {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "2",
                   ],
@@ -208,9 +208,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "π",
                   ],
@@ -219,9 +219,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "i",
                   ],
@@ -230,9 +230,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "ξ",
                   ],
@@ -241,9 +241,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "x",
                   ],
@@ -258,9 +258,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
       ],
       "rootKey": "m:sSup",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             ",",
           ],
@@ -269,9 +269,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "d",
           ],
@@ -280,9 +280,9 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ξ",
           ],
@@ -298,13 +298,13 @@ exports[`parse \\f\\relax{x} = \\int_{-\\infty}^\\infty\\f\\hat\\xi\\,e^{2 \\pi 
 exports[`parse \\frac{a+b}{c+d} 1`] = `
 [
   [
-    Jn {
+    MathFraction {
       "root": [
-        Yn {
+        MathNumerator {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "a",
                   ],
@@ -313,9 +313,9 @@ exports[`parse \\frac{a+b}{c+d} 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "+",
                   ],
@@ -324,9 +324,9 @@ exports[`parse \\frac{a+b}{c+d} 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "b",
                   ],
@@ -338,11 +338,11 @@ exports[`parse \\frac{a+b}{c+d} 1`] = `
           ],
           "rootKey": "m:num",
         },
-        Zn {
+        MathDenominator {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "c",
                   ],
@@ -351,9 +351,9 @@ exports[`parse \\frac{a+b}{c+d} 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "+",
                   ],
@@ -362,9 +362,9 @@ exports[`parse \\frac{a+b}{c+d} 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "d",
                   ],
@@ -386,17 +386,17 @@ exports[`parse \\frac{a+b}{c+d} 1`] = `
 exports[`parse \\sqrt[30]{a+\\sqrt{b+c}} 1`] = `
 [
   [
-    Ss {
+    MathRadical {
       "root": [
-        As {
+        MathRadicalProperties {
           "root": [],
           "rootKey": "m:radPr",
         },
-        _s {
+        MathDegree {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "3",
                   ],
@@ -405,9 +405,9 @@ exports[`parse \\sqrt[30]{a+\\sqrt{b+c}} 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "0",
                   ],
@@ -419,11 +419,11 @@ exports[`parse \\sqrt[30]{a+\\sqrt{b+c}} 1`] = `
           ],
           "rootKey": "m:deg",
         },
-        ts {
+        MathBase {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "a",
                   ],
@@ -432,9 +432,9 @@ exports[`parse \\sqrt[30]{a+\\sqrt{b+c}} 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "+",
                   ],
@@ -443,9 +443,9 @@ exports[`parse \\sqrt[30]{a+\\sqrt{b+c}} 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "sqrt",
                   ],
@@ -467,29 +467,29 @@ exports[`parse \\sqrt[30]{a+\\sqrt{b+c}} 1`] = `
 exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
 [
   [
-    fs {
+    MathSuperScript {
       "root": [
-        ds {
+        MathSuperScriptProperties {
           "root": [],
           "rootKey": "m:sSupPr",
         },
-        ts {
+        MathBase {
           "root": [
-            ws {
+            MathSubScript {
               "root": [
-                ms {
+                MathSubScriptProperties {
                   "root": [],
                   "rootKey": "m:sSubPr",
                 },
-                ts {
+                MathBase {
                   "root": [
-                    hs {
+                    MathSum {
                       "root": [
-                        cs {
+                        MathNAryProperties {
                           "root": [
-                            es {
+                            MathAccentCharacter {
                               "root": [
-                                Qn {
+                                MathAccentCharacterAttributes {
                                   "root": {
                                     "accent": "∑",
                                   },
@@ -501,9 +501,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
                               ],
                               "rootKey": "m:chr",
                             },
-                            ns {
+                            MathLimitLocation {
                               "root": [
-                                rs {
+                                MathLimitLocationAttributes {
                                   "root": {
                                     "value": "undOvr",
                                   },
@@ -515,9 +515,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
                               ],
                               "rootKey": "m:limLoc",
                             },
-                            as {
+                            MathSuperScriptHide {
                               "root": [
-                                os {
+                                MathSuperScriptHideAttributes {
                                   "root": {
                                     "hide": 1,
                                   },
@@ -529,9 +529,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
                               ],
                               "rootKey": "m:supHide",
                             },
-                            is {
+                            MathSubScriptHide {
                               "root": [
-                                ss {
+                                MathSubScriptHideAttributes {
                                   "root": {
                                     "hide": 1,
                                   },
@@ -546,7 +546,7 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
                           ],
                           "rootKey": "m:naryPr",
                         },
-                        ts {
+                        MathBase {
                           "root": [],
                           "rootKey": "m:e",
                         },
@@ -556,11 +556,11 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
                   ],
                   "rootKey": "m:e",
                 },
-                us {
+                MathSubScriptElement {
                   "root": [
-                    $n {
+                    MathRun {
                       "root": [
-                        Xn {
+                        MathText {
                           "root": [
                             "k",
                           ],
@@ -569,9 +569,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
                       ],
                       "rootKey": "m:r",
                     },
-                    $n {
+                    MathRun {
                       "root": [
-                        Xn {
+                        MathText {
                           "root": [
                             "=",
                           ],
@@ -580,9 +580,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
                       ],
                       "rootKey": "m:r",
                     },
-                    $n {
+                    MathRun {
                       "root": [
-                        Xn {
+                        MathText {
                           "root": [
                             "1",
                           ],
@@ -600,11 +600,11 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
           ],
           "rootKey": "m:e",
         },
-        ls {
+        MathSuperScriptElement {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "n",
                   ],
@@ -619,9 +619,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
       ],
       "rootKey": "m:sSup",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "k",
           ],
@@ -630,9 +630,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "=",
           ],
@@ -641,9 +641,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "",
           ],
@@ -652,9 +652,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "r",
           ],
@@ -663,9 +663,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "a",
           ],
@@ -674,9 +674,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "c",
           ],
@@ -685,9 +685,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "n",
           ],
@@ -696,9 +696,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "(",
           ],
@@ -707,9 +707,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "n",
           ],
@@ -718,9 +718,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "+",
           ],
@@ -729,9 +729,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "1",
           ],
@@ -740,9 +740,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             ")",
           ],
@@ -751,9 +751,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "2",
           ],
@@ -769,9 +769,9 @@ exports[`parse \\sum_{k=1}^{n} k=rac{n(n+1)}{2} 1`] = `
 exports[`parse L = \\frac{1}{2} \\rho v^2 S C_L 1`] = `
 [
   [
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "L",
           ],
@@ -780,9 +780,9 @@ exports[`parse L = \\frac{1}{2} \\rho v^2 S C_L 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "=",
           ],
@@ -791,13 +791,13 @@ exports[`parse L = \\frac{1}{2} \\rho v^2 S C_L 1`] = `
       ],
       "rootKey": "m:r",
     },
-    Jn {
+    MathFraction {
       "root": [
-        Yn {
+        MathNumerator {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "1",
                   ],
@@ -809,11 +809,11 @@ exports[`parse L = \\frac{1}{2} \\rho v^2 S C_L 1`] = `
           ],
           "rootKey": "m:num",
         },
-        Zn {
+        MathDenominator {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "2",
                   ],
@@ -828,9 +828,9 @@ exports[`parse L = \\frac{1}{2} \\rho v^2 S C_L 1`] = `
       ],
       "rootKey": "m:f",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ρ",
           ],
@@ -839,17 +839,17 @@ exports[`parse L = \\frac{1}{2} \\rho v^2 S C_L 1`] = `
       ],
       "rootKey": "m:r",
     },
-    fs {
+    MathSuperScript {
       "root": [
-        ds {
+        MathSuperScriptProperties {
           "root": [],
           "rootKey": "m:sSupPr",
         },
-        ts {
+        MathBase {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "v",
                   ],
@@ -861,11 +861,11 @@ exports[`parse L = \\frac{1}{2} \\rho v^2 S C_L 1`] = `
           ],
           "rootKey": "m:e",
         },
-        ls {
+        MathSuperScriptElement {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "2",
                   ],
@@ -880,9 +880,9 @@ exports[`parse L = \\frac{1}{2} \\rho v^2 S C_L 1`] = `
       ],
       "rootKey": "m:sSup",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "S",
           ],
@@ -891,17 +891,17 @@ exports[`parse L = \\frac{1}{2} \\rho v^2 S C_L 1`] = `
       ],
       "rootKey": "m:r",
     },
-    ws {
+    MathSubScript {
       "root": [
-        ms {
+        MathSubScriptProperties {
           "root": [],
           "rootKey": "m:sSubPr",
         },
-        ts {
+        MathBase {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "C",
                   ],
@@ -913,11 +913,11 @@ exports[`parse L = \\frac{1}{2} \\rho v^2 S C_L 1`] = `
           ],
           "rootKey": "m:e",
         },
-        us {
+        MathSubScriptElement {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "L",
                   ],
@@ -939,9 +939,9 @@ exports[`parse L = \\frac{1}{2} \\rho v^2 S C_L 1`] = `
 exports[`parse command greek1 1`] = `
 [
   [
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "α",
           ],
@@ -950,9 +950,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "β",
           ],
@@ -961,9 +961,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "γ",
           ],
@@ -972,9 +972,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "δ",
           ],
@@ -983,9 +983,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ϵ",
           ],
@@ -994,9 +994,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ζ",
           ],
@@ -1005,9 +1005,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "η",
           ],
@@ -1016,9 +1016,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "θ",
           ],
@@ -1027,9 +1027,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ι",
           ],
@@ -1038,9 +1038,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "κ",
           ],
@@ -1049,9 +1049,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "λ",
           ],
@@ -1060,9 +1060,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "μ",
           ],
@@ -1071,9 +1071,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ν",
           ],
@@ -1082,9 +1082,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ξ",
           ],
@@ -1093,9 +1093,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "o",
           ],
@@ -1104,9 +1104,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "π",
           ],
@@ -1115,9 +1115,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ρ",
           ],
@@ -1126,9 +1126,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "σ",
           ],
@@ -1137,9 +1137,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "τ",
           ],
@@ -1148,9 +1148,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "υ",
           ],
@@ -1159,9 +1159,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ϕ",
           ],
@@ -1170,9 +1170,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "χ",
           ],
@@ -1181,9 +1181,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ψ",
           ],
@@ -1192,9 +1192,9 @@ exports[`parse command greek1 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ω",
           ],
@@ -1210,9 +1210,9 @@ exports[`parse command greek1 1`] = `
 exports[`parse command greek2 1`] = `
 [
   [
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ε",
           ],
@@ -1221,9 +1221,9 @@ exports[`parse command greek2 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ϑ",
           ],
@@ -1232,9 +1232,9 @@ exports[`parse command greek2 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ϱ",
           ],
@@ -1243,9 +1243,9 @@ exports[`parse command greek2 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "ς",
           ],
@@ -1254,9 +1254,9 @@ exports[`parse command greek2 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "φ",
           ],
@@ -1272,9 +1272,9 @@ exports[`parse command greek2 1`] = `
 exports[`parse command greek3 1`] = `
 [
   [
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "Γ",
           ],
@@ -1283,9 +1283,9 @@ exports[`parse command greek3 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "Δ",
           ],
@@ -1294,9 +1294,9 @@ exports[`parse command greek3 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "Θ",
           ],
@@ -1305,9 +1305,9 @@ exports[`parse command greek3 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "Λ",
           ],
@@ -1316,9 +1316,9 @@ exports[`parse command greek3 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "Ξ",
           ],
@@ -1327,9 +1327,9 @@ exports[`parse command greek3 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "Π",
           ],
@@ -1338,9 +1338,9 @@ exports[`parse command greek3 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "Σ",
           ],
@@ -1349,9 +1349,9 @@ exports[`parse command greek3 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "Υ",
           ],
@@ -1360,9 +1360,9 @@ exports[`parse command greek3 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "Φ",
           ],
@@ -1371,9 +1371,9 @@ exports[`parse command greek3 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "Ψ",
           ],
@@ -1382,9 +1382,9 @@ exports[`parse command greek3 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "Ω",
           ],
@@ -1400,9 +1400,9 @@ exports[`parse command greek3 1`] = `
 exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
 [
   [
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "i",
           ],
@@ -1411,9 +1411,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "h",
           ],
@@ -1422,9 +1422,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "b",
           ],
@@ -1433,9 +1433,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "a",
           ],
@@ -1444,9 +1444,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "r",
           ],
@@ -1455,13 +1455,13 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:r",
     },
-    Jn {
+    MathFraction {
       "root": [
-        Yn {
+        MathNumerator {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "p",
                   ],
@@ -1470,9 +1470,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "a",
                   ],
@@ -1481,9 +1481,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "r",
                   ],
@@ -1492,9 +1492,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "t",
                   ],
@@ -1503,9 +1503,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "i",
                   ],
@@ -1514,9 +1514,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "a",
                   ],
@@ -1525,9 +1525,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "l",
                   ],
@@ -1536,9 +1536,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "p",
                   ],
@@ -1547,9 +1547,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "s",
                   ],
@@ -1558,9 +1558,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "i",
                   ],
@@ -1572,11 +1572,11 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
           ],
           "rootKey": "m:num",
         },
-        Zn {
+        MathDenominator {
           "root": [
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "p",
                   ],
@@ -1585,9 +1585,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "a",
                   ],
@@ -1596,9 +1596,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "r",
                   ],
@@ -1607,9 +1607,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "t",
                   ],
@@ -1618,9 +1618,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "i",
                   ],
@@ -1629,9 +1629,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "a",
                   ],
@@ -1640,9 +1640,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "l",
                   ],
@@ -1651,9 +1651,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
               ],
               "rootKey": "m:r",
             },
-            $n {
+            MathRun {
               "root": [
-                Xn {
+                MathText {
                   "root": [
                     "t",
                   ],
@@ -1668,9 +1668,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:f",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "=",
           ],
@@ -1679,9 +1679,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "H",
           ],
@@ -1690,9 +1690,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "p",
           ],
@@ -1701,9 +1701,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "s",
           ],
@@ -1712,9 +1712,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "i",
           ],
@@ -1723,9 +1723,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "(",
           ],
@@ -1734,9 +1734,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "x",
           ],
@@ -1745,9 +1745,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             ",",
           ],
@@ -1756,9 +1756,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             "t",
           ],
@@ -1767,9 +1767,9 @@ exports[`parse i hbar \\frac{partial psi}{partial t} = H psi(x,t) 1`] = `
       ],
       "rootKey": "m:r",
     },
-    $n {
+    MathRun {
       "root": [
-        Xn {
+        MathText {
           "root": [
             ")",
           ],

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -100,11 +100,9 @@ export type ImageData = {
 
 export type ImageResolver = (url: string) => Promise<ImageData> | ImageData;
 
-type Decoration = Readonly<
-  {
-    [key in (mdast.Emphasis | mdast.Strong | mdast.Delete)["type"]]?: true;
-  }
->;
+type Decoration = Readonly<{
+  [key in (mdast.Emphasis | mdast.Strong | mdast.Delete)["type"]]?: true;
+}>;
 
 type ListInfo = Readonly<{
   level: number;
@@ -154,7 +152,7 @@ export interface ConvertNodesReturn {
   footnotes: Footnotes;
 }
 
-export const mdastToDocx = (
+export const mdastToDocx = async (
   node: mdast.Root,
   {
     output = "buffer",
@@ -199,7 +197,11 @@ export const mdastToDocx = (
 
   switch (output) {
     case "buffer":
-      return Packer.toBuffer(doc);
+      const bufOut = await Packer.toBuffer(doc);
+      // feature detection instead of environment detection, but if Buffer exists
+      // it's probably Node. If not, return the Uint8Array that JSZip returns
+      // when it doesn't detect a Node environment.
+      return typeof Buffer === "function" ? Buffer.from(bufOut) : bufOut;
     case "blob":
       return Packer.toBlob(doc);
   }


### PR DESCRIPTION
Resolves #36.

- Updates `docx` version to 8.1.0, which uses package.json exports correctly and supports direct ESM import
- Updates `unist-util-visit` to current release
- Uses the modern package.json `exports` field to conditionally export for module formats
- Removes reliance on unstable import assertions (not strictly necessary to resolve #36 but falls in the category of ESM compatibility)