### PR TITLE
fix: code blocks without or with unknown language result in broken .docx

### DIFF
--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -313,9 +313,9 @@ quote</w:t></w:r></w:p><w:p><w:pPr><w:ind
                 xml:space="preserve"
               >aligned</w:t></w:r></w:p></w:tc></w:tr></w:tbl><w:p><w:r><w:br
           w:type="page"
-        /></w:r></w:p><w:p><w:r><w:br w:type="page" /></w:r></w:p><w:r><w:t
-        xml:space="preserve"
-      >function $initHighlight(block, cls) {
+        /></w:r></w:p><w:p><w:r><w:br w:type="page" /></w:r></w:p><w:p><w:r><w:t
+          xml:space="preserve"
+        >function $initHighlight(block, cls) {
   try {
     if (cls.search(/\\bno\\-highlight\\b/) != -1)
       return process(block, true, 0x0F) +
@@ -335,7 +335,7 @@ quote</w:t></w:r></w:p><w:p><w:pPr><w:ind
   )
 }
 
-export  $initHighlight;</w:t></w:r><w:sectPr><w:pgSz
+export  $initHighlight;</w:t></w:r></w:p><w:sectPr><w:pgSz
         w:w="11906"
         w:h="16838"
         w:orient="portrait"
@@ -1152,10 +1152,10 @@ quote</w:t></w:r></w:p><w:p><w:pPr><w:bidi /><w:ind
                 xml:space="preserve"
               >aligned</w:t></w:r></w:p></w:tc></w:tr></w:tbl><w:p><w:r><w:br
           w:type="page"
-        /></w:r></w:p><w:p><w:r><w:br w:type="page" /></w:r></w:p><w:r><w:rPr
-      ><w:rtl /></w:rPr><w:t
-        xml:space="preserve"
-      >function $initHighlight(block, cls) {
+        /></w:r></w:p><w:p><w:r><w:br w:type="page" /></w:r></w:p><w:p><w:pPr
+      ><w:bidi /></w:pPr><w:r><w:rPr><w:rtl /></w:rPr><w:t
+          xml:space="preserve"
+        >function $initHighlight(block, cls) {
   try {
     if (cls.search(/\\bno\\-highlight\\b/) != -1)
       return process(block, true, 0x0F) +
@@ -1175,7 +1175,7 @@ quote</w:t></w:r></w:p><w:p><w:pPr><w:bidi /><w:ind
   )
 }
 
-export  $initHighlight;</w:t></w:r><w:sectPr><w:pgSz
+export  $initHighlight;</w:t></w:r></w:p><w:sectPr><w:pgSz
         w:w="11906"
         w:h="16838"
         w:orient="portrait"
@@ -3867,9 +3867,9 @@ exports[`e2e > code 1`] = `
             w:val="false"
           /><w:color w:val="6A9955" /></w:rPr><w:t
           xml:space="preserve"
-        >// fat arrow syntax</w:t></w:r></w:p><w:r><w:t
-        xml:space="preserve"
-      >unknown lang</w:t></w:r><w:sectPr><w:pgSz
+        >// fat arrow syntax</w:t></w:r></w:p><w:p><w:r><w:t
+          xml:space="preserve"
+        >unknown lang</w:t></w:r></w:p><w:sectPr><w:pgSz
         w:w="11906"
         w:h="16838"
         w:orient="portrait"
@@ -5425,7 +5425,9 @@ exports[`e2e > footnotes 4`] = `
     ><w:r><w:t
           xml:space="preserve"
         >Indent paragraphs to include them in the footnote.</w:t></w:r></w:p><w:p
-    ><w:r><w:t
+    ><w:r><w:t xml:space="preserve">function add(a, b) {
+  return a + b;
+}</w:t></w:r></w:p><w:p><w:r><w:t
           xml:space="preserve"
         >Add as many paragraphs as you like.</w:t></w:r></w:p></w:footnote><w:footnote
     w:id="6"

--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -315,27 +315,44 @@ quote</w:t></w:r></w:p><w:p><w:pPr><w:ind
           w:type="page"
         /></w:r></w:p><w:p><w:r><w:br w:type="page" /></w:r></w:p><w:p><w:r><w:t
           xml:space="preserve"
-        >function $initHighlight(block, cls) {
-  try {
-    if (cls.search(/\\bno\\-highlight\\b/) != -1)
-      return process(block, true, 0x0F) +
-             \` class=&quot;\${cls}&quot;\`;
-  } catch (e) {
-    /* handle exception */
-  }
-  for (var i = 0 / 2; i &lt; classes.length; i++) {
-    if (checkCondition(classes[i]) === undefined)
-      console.log(&apos;undefined&apos;);
-  }
-
-  return (
-    &lt;div&gt;
-      &lt;web-component&gt;{block}&lt;/web-component&gt;
-    &lt;/div&gt;
-  )
-}
-
-export  $initHighlight;</w:t></w:r></w:p><w:sectPr><w:pgSz
+        >function $initHighlight(block, cls) {</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >  try {</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >    if (cls.search(/\\bno\\-highlight\\b/) != -1)</w:t></w:r><w:r><w:br
+        /><w:t
+          xml:space="preserve"
+        >      return process(block, true, 0x0F) +</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >             \` class=&quot;\${cls}&quot;\`;</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >  } catch (e) {</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >    /* handle exception */</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >  }</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >  for (var i = 0 / 2; i &lt; classes.length; i++) {</w:t></w:r><w:r
+      ><w:br /><w:t
+          xml:space="preserve"
+        >    if (checkCondition(classes[i]) === undefined)</w:t></w:r><w:r><w:br
+        /><w:t
+          xml:space="preserve"
+        >      console.log(&apos;undefined&apos;);</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >  }</w:t></w:r><w:r><w:br /><w:t xml:space="preserve" /></w:r><w:r
+      ><w:br /><w:t xml:space="preserve">  return (</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >    &lt;div&gt;</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >      &lt;web-component&gt;{block}&lt;/web-component&gt;</w:t></w:r><w:r
+      ><w:br /><w:t xml:space="preserve">    &lt;/div&gt;</w:t></w:r><w:r><w:br
+        /><w:t xml:space="preserve">  )</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >}</w:t></w:r><w:r><w:br /><w:t xml:space="preserve" /></w:r><w:r><w:br
+        /><w:t
+          xml:space="preserve"
+        >export  $initHighlight;</w:t></w:r></w:p><w:sectPr><w:pgSz
         w:w="11906"
         w:h="16838"
         w:orient="portrait"
@@ -1152,30 +1169,46 @@ quote</w:t></w:r></w:p><w:p><w:pPr><w:bidi /><w:ind
                 xml:space="preserve"
               >aligned</w:t></w:r></w:p></w:tc></w:tr></w:tbl><w:p><w:r><w:br
           w:type="page"
-        /></w:r></w:p><w:p><w:r><w:br w:type="page" /></w:r></w:p><w:p><w:pPr
-      ><w:bidi /></w:pPr><w:r><w:rPr><w:rtl /></w:rPr><w:t
+        /></w:r></w:p><w:p><w:r><w:br w:type="page" /></w:r></w:p><w:p><w:r><w:t
           xml:space="preserve"
-        >function $initHighlight(block, cls) {
-  try {
-    if (cls.search(/\\bno\\-highlight\\b/) != -1)
-      return process(block, true, 0x0F) +
-             \` class=&quot;\${cls}&quot;\`;
-  } catch (e) {
-    /* handle exception */
-  }
-  for (var i = 0 / 2; i &lt; classes.length; i++) {
-    if (checkCondition(classes[i]) === undefined)
-      console.log(&apos;undefined&apos;);
-  }
-
-  return (
-    &lt;div&gt;
-      &lt;web-component&gt;{block}&lt;/web-component&gt;
-    &lt;/div&gt;
-  )
-}
-
-export  $initHighlight;</w:t></w:r></w:p><w:sectPr><w:pgSz
+        >function $initHighlight(block, cls) {</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >  try {</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >    if (cls.search(/\\bno\\-highlight\\b/) != -1)</w:t></w:r><w:r><w:br
+        /><w:t
+          xml:space="preserve"
+        >      return process(block, true, 0x0F) +</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >             \` class=&quot;\${cls}&quot;\`;</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >  } catch (e) {</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >    /* handle exception */</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >  }</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >  for (var i = 0 / 2; i &lt; classes.length; i++) {</w:t></w:r><w:r
+      ><w:br /><w:t
+          xml:space="preserve"
+        >    if (checkCondition(classes[i]) === undefined)</w:t></w:r><w:r><w:br
+        /><w:t
+          xml:space="preserve"
+        >      console.log(&apos;undefined&apos;);</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >  }</w:t></w:r><w:r><w:br /><w:t xml:space="preserve" /></w:r><w:r
+      ><w:br /><w:t xml:space="preserve">  return (</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >    &lt;div&gt;</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >      &lt;web-component&gt;{block}&lt;/web-component&gt;</w:t></w:r><w:r
+      ><w:br /><w:t xml:space="preserve">    &lt;/div&gt;</w:t></w:r><w:r><w:br
+        /><w:t xml:space="preserve">  )</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >}</w:t></w:r><w:r><w:br /><w:t xml:space="preserve" /></w:r><w:r><w:br
+        /><w:t
+          xml:space="preserve"
+        >export  $initHighlight;</w:t></w:r></w:p><w:sectPr><w:pgSz
         w:w="11906"
         w:h="16838"
         w:orient="portrait"
@@ -5425,9 +5458,10 @@ exports[`e2e > footnotes 4`] = `
     ><w:r><w:t
           xml:space="preserve"
         >Indent paragraphs to include them in the footnote.</w:t></w:r></w:p><w:p
-    ><w:r><w:t xml:space="preserve">function add(a, b) {
-  return a + b;
-}</w:t></w:r></w:p><w:p><w:r><w:t
+    ><w:r><w:t xml:space="preserve">function add(a, b) {</w:t></w:r><w:r><w:br
+        /><w:t xml:space="preserve">  return a + b;</w:t></w:r><w:r><w:br /><w:t
+          xml:space="preserve"
+        >}</w:t></w:r></w:p><w:p><w:r><w:t
           xml:space="preserve"
         >Add as many paragraphs as you like.</w:t></w:r></w:p></w:footnote><w:footnote
     w:id="6"

--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -1169,7 +1169,8 @@ quote</w:t></w:r></w:p><w:p><w:pPr><w:bidi /><w:ind
                 xml:space="preserve"
               >aligned</w:t></w:r></w:p></w:tc></w:tr></w:tbl><w:p><w:r><w:br
           w:type="page"
-        /></w:r></w:p><w:p><w:r><w:br w:type="page" /></w:r></w:p><w:p><w:r><w:t
+        /></w:r></w:p><w:p><w:r><w:br w:type="page" /></w:r></w:p><w:p><w:pPr
+      ><w:bidi /></w:pPr><w:r><w:t
           xml:space="preserve"
         >function $initHighlight(block, cls) {</w:t></w:r><w:r><w:br /><w:t
           xml:space="preserve"

--- a/src/mdast-util-to-docx.ts
+++ b/src/mdast-util-to-docx.ts
@@ -287,7 +287,7 @@ export const mdastToDocx = async (
       tableRow: noop,
       tableCell: noop,
       html: fallbackText,
-      code: fallbackText,
+      code: fallbackCode,
       definition: noop,
       footnoteDefinition: buildFootnoteDefinition,
       text: buildText,
@@ -818,11 +818,24 @@ const fallbackText = (node: { type: string; value: string }, ctx: Context) => {
   warnOnce(
     `${node.type} node is not supported without plugins, falling back to text.`,
   );
-  const text = buildText({ type: "text", value: node.value }, ctx) as TextRun;
+  return buildText({ type: "text", value: node.value }, ctx);
+};
+
+const fallbackCode = (node: { type: string; value: string }, ctx: Context) => {
+  warnOnce(
+    `${node.type} node is not supported without plugins, falling back to text.`,
+  );
+  const children = node.value.split(/\r?\n/).map(
+    (line, index) =>
+      new TextRun({
+        text: line,
+        break: index === 0 ? undefined : 1,
+      }),
+  );
   return docxParagraph(
     {
-      children: [text],
+      children,
     },
-    ctx,
+    { ...ctx, rtl: false },
   );
 };

--- a/src/mdast-util-to-docx.ts
+++ b/src/mdast-util-to-docx.ts
@@ -818,5 +818,11 @@ const fallbackText = (node: { type: string; value: string }, ctx: Context) => {
   warnOnce(
     `${node.type} node is not supported without plugins, falling back to text.`,
   );
-  return buildText({ type: "text", value: node.value }, ctx);
+  const text = buildText({ type: "text", value: node.value }, ctx) as TextRun;
+  return docxParagraph(
+    {
+      children: [text],
+    },
+    ctx,
+  );
 };

--- a/src/mdast-util-to-docx.ts
+++ b/src/mdast-util-to-docx.ts
@@ -836,6 +836,6 @@ const fallbackCode = (node: { type: string; value: string }, ctx: Context) => {
     {
       children,
     },
-    { ...ctx, rtl: false },
+    ctx,
   );
 };


### PR DESCRIPTION
# Bugfix

## Issue

Code blocks without language, like:
```
some code
```

and code blocks with unknown languages, like:
```some-unknown-language
some code
```

result in broken .docx documents, for which users see the following error when opening them with Microsoft Word:
<img width="256" height="341" alt="image" src="https://github.com/user-attachments/assets/c61ae4cf-ff71-4641-a58d-55d803be1520" />

The reason is that the generated .docx document contains text run elements `<w:r>` directly under the `<w:body>` element, which violates Office Open XML standard, as far as I can tell from
https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.body?view=openxml-3.0.1#remarks

These text run elements are only generated when no language or an unknown language is used because in that case the docx-generation falls back to the `fallbackText` function.

**Important**: LibreOffice Writer and Apple Pages do open the .docx file. But they do not show the broken text run elements.

## Step-by-step Reproduction

1. Check out `main` branch.
2. Create the .docx file that the "code" e2e test would produce, e.g. with the scripts in the supplementary material below.
3. Try to open the generated .docx file with **Microsoft Word**.

## Fix

This change fixes the issue by introducing a dedicated `fallbackCode` function.
That function returns wrapping the code text in a paragraph element `<w:p>` with text direction left-to-right.
Line breaks in the code text are preserved within that paragraph with "simple" line breaks (not "paragraph breaks"), i.e. `<w:br /> elements.

E2e test fixtures had to be changed to expect the additional elements, i.e. `<w:p>`, `<w:br />`, etc. This was necessary because the tests did expect invalid docx snapshots.

## Supplementary Material

Shell script and JavaScript file to create the .docx file that the "code" e2e test would produce:
(Put both files in the repository root directory)
```bash
#!/bin/bash

echo 'Builing remark-docx...'
npm run build

# Exporting result of "code" e2e test as .docx file
node write-code-fixture-docx.mjs code-e2e-test-result.docx
```

`write-code-fixture-docx.mjs` JavaScript file:
```javascript
import fs from "node:fs/promises";
import path from "node:path";
import { fileURLToPath } from "node:url";
import { unified } from "unified";
import markdown from "remark-parse";
import gfm from "remark-gfm";
import frontmatter from "remark-frontmatter";
import math from "remark-math";
import docx from "./lib/index.js";
import { shikiPlugin } from "./lib/plugins/shiki/index.js";

const root = path.resolve(fileURLToPath(new URL(".", import.meta.url)));
const outputPath = path.resolve(
  root,
  process.argv[2] ?? "code-e2e-test-result.docx",
);

console.log('')
console.log('Exporting result of "code" e2e test as .docx file...')
console.log('')

const md = await fs.readFile(path.join(root, "fixtures/code.md"));
const doc = await unified()
  .use(markdown)
  .use(gfm)
  .use(frontmatter, ["yaml", "toml"])
  .use(math)
  .use(docx, {
    plugins: [shikiPlugin({ theme: "dark-plus" })],
  })
  .process(md);

await fs.mkdir(path.dirname(outputPath), { recursive: true });
await fs.writeFile(outputPath, Buffer.from(await doc.result));

console.log('Wrote file:')
console.log('')
console.log(`  ${outputPath}`);
console.log('')
```
